### PR TITLE
Add print option and update question selector layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,9 +23,10 @@
 
 
             <p class="text-md text-gray-500 mb-4">Estilo: FUNDATEC, VUNESP e IBFC.</p>
-            <form id="config-form" class="text-left mb-6">
-                <label class="block mb-2">Quantidade de questões:
-                    <select id="num-questions" class="border rounded p-1 ml-2">
+            <form id="config-form" class="text-left mb-6 space-y-4">
+                <label class="flex flex-col sm:flex-row items-center gap-2">
+                    <span>Quantidade de questões:</span>
+                    <select id="num-questions" class="border rounded p-1">
                         <option value="5">5</option>
                         <option value="10" selected>10</option>
                         <option value="20">20</option>
@@ -34,11 +35,13 @@
                 </label>
                 <fieldset class="mb-2">
                     <legend class="font-semibold mb-1">Áreas</legend>
-                    <label class="mr-3"><input type="checkbox" name="areas" value="Otologia" checked class="mr-1">Otologia</label>
-                    <label class="mr-3"><input type="checkbox" name="areas" value="Rinologia" checked class="mr-1">Rinologia</label>
-                    <label class="mr-3"><input type="checkbox" name="areas" value="Laringologia e Bucofaringe" checked class="mr-1">Laringologia e Bucofaringe</label>
-                    <label class="mr-3"><input type="checkbox" name="areas" value="Urgências e Miscelânea" checked class="mr-1">Urgências e Miscelânea</label>
-                    <label class="mr-3"><input type="checkbox" name="areas" value="Legislação do SUS" checked class="mr-1">Legislação do SUS</label>
+                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                        <label class="flex items-center"><input type="checkbox" name="areas" value="Otologia" checked class="mr-1">Otologia</label>
+                        <label class="flex items-center"><input type="checkbox" name="areas" value="Rinologia" checked class="mr-1">Rinologia</label>
+                        <label class="flex items-center"><input type="checkbox" name="areas" value="Laringologia e Bucofaringe" checked class="mr-1">Laringologia e Bucofaringe</label>
+                        <label class="flex items-center"><input type="checkbox" name="areas" value="Urgências e Miscelânea" checked class="mr-1">Urgências e Miscelânea</label>
+                        <label class="flex items-center"><input type="checkbox" name="areas" value="Legislação do SUS" checked class="mr-1">Legislação do SUS</label>
+                    </div>
                 </fieldset>
             </form>
 
@@ -83,6 +86,9 @@
             <p id="score-message" class="text-lg text-gray-600 mb-8"></p>
             <button id="restart-btn" class="bg-[#004AAD] hover:bg-[#003B8A] text-white font-bold py-3 px-8 rounded-lg text-xl shadow-md transition-transform transform hover:scale-105">
                 Refazer Simulado
+            </button>
+            <button id="print-btn" class="mt-4 bg-[#0094D1] hover:bg-[#007EAF] text-white font-bold py-3 px-8 rounded-lg text-xl shadow-md transition-transform transform hover:scale-105">
+                Imprimir Resultado
             </button>
         </div>
 

--- a/script.js
+++ b/script.js
@@ -13,6 +13,7 @@ const resultsScreen = document.getElementById('results-screen');
 const startBtn = document.getElementById('start-btn');
 const nextBtn = document.getElementById('next-btn');
 const restartBtn = document.getElementById('restart-btn');
+const printBtn = document.getElementById('print-btn');
 
 const progressBar = document.getElementById('progress-bar');
 const questionCounterEl = document.getElementById('question-counter');
@@ -169,4 +170,7 @@ nextBtn.addEventListener('click', () => {
     showQuestion();
 });
 restartBtn.addEventListener('click', startQuiz);
+if (printBtn) {
+    printBtn.addEventListener('click', () => window.print());
+}
 

--- a/styles.css
+++ b/styles.css
@@ -22,3 +22,15 @@ body {
     border-color: #ef4444 !important;
     color: #991b1b;
 }
+
+@media print {
+    #start-screen,
+    #quiz-screen,
+    #restart-btn,
+    #print-btn {
+        display: none !important;
+    }
+    body {
+        background-color: #fff;
+    }
+}


### PR DESCRIPTION
## Summary
- streamline the start screen selector layout with grid and spacing
- add a print results button and hook up printing
- hide interactive elements when printing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e897d655c832b9ae76a7fb7002359