### PR TITLE
Add range selector for question count

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,16 +25,17 @@
             <p class="text-md text-gray-500 mb-4">Estilo: FUNDATEC, VUNESP e IBFC.</p>
             <form id="config-form" class="text-left mb-6 space-y-4">
                 <label class="flex flex-col sm:flex-row items-center gap-2">
-                    <span>Quantidade de questões:</span>
-                    <select id="num-questions" class="border rounded p-1">
-
-                        <option value="10" selected>10</option>
-                        <option value="20">20</option>
-                        <option value="30">30</option>
-                        <option value="40">40</option>
-                        <option value="50">50</option>
-                    </select>
+                    <span class="whitespace-nowrap">Quantidade de questões:</span>
+                    <input id="num-questions" type="range" min="10" max="50" step="10" value="10" list="question-steps" class="flex-1 accent-[#004AAD]">
+                    <span id="num-questions-value" class="ml-2 font-semibold">10</span>
                 </label>
+                <datalist id="question-steps">
+                    <option value="10"></option>
+                    <option value="20"></option>
+                    <option value="30"></option>
+                    <option value="40"></option>
+                    <option value="50"></option>
+                </datalist>
                 <fieldset class="mb-2">
                     <legend class="font-semibold mb-1">Áreas</legend>
                     <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">

--- a/script.js
+++ b/script.js
@@ -27,8 +27,16 @@ const finalScoreEl = document.getElementById('final-score');
 const scoreMessageEl = document.getElementById('score-message');
 
 const numQuestionsInput = document.getElementById('num-questions');
+const numQuestionsValue = document.getElementById('num-questions-value');
 const areaCheckboxes = document.querySelectorAll('input[name="areas"]');
 const timerEl = document.getElementById('timer');
+
+if (numQuestionsInput && numQuestionsValue) {
+    numQuestionsValue.textContent = numQuestionsInput.value;
+    numQuestionsInput.addEventListener('input', () => {
+        numQuestionsValue.textContent = numQuestionsInput.value;
+    });
+}
 
 let timerInterval;
 let timeLeft = 0;

--- a/styles.css
+++ b/styles.css
@@ -23,6 +23,36 @@ body {
     color: #991b1b;
 }
 
+input[type=range] {
+    height: 1.25rem;
+    background-color: transparent;
+}
+input[type=range]::-webkit-slider-runnable-track {
+    height: 0.5rem;
+    background-color: #e5e7eb;
+    border-radius: 9999px;
+}
+input[type=range]::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    height: 1rem;
+    width: 1rem;
+    background-color: #004AAD;
+    border-radius: 9999px;
+    margin-top: -0.25rem;
+}
+input[type=range]::-moz-range-track {
+    height: 0.5rem;
+    background-color: #e5e7eb;
+    border-radius: 9999px;
+}
+input[type=range]::-moz-range-thumb {
+    height: 1rem;
+    width: 1rem;
+    background-color: #004AAD;
+    border: none;
+    border-radius: 9999px;
+}
+
 @media print {
     #start-screen,
     #quiz-screen,


### PR DESCRIPTION
## Summary
- swap question count dropdown for a range slider showing the current value
- update script to sync the slider value and use it when starting the quiz
- style the range input for a consistent appearance

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686f1c208b0c832b874b8192ca2de0aa