### PR TITLE
Add checkboxes for new quiz areas

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,8 @@
                         <label class="flex items-center"><input type="checkbox" name="areas" value="Laringologia e Bucofaringe" checked class="mr-1">Laringologia e Bucofaringe</label>
                         <label class="flex items-center"><input type="checkbox" name="areas" value="Urgências e Miscelânea" checked class="mr-1">Urgências e Miscelânea</label>
                         <label class="flex items-center"><input type="checkbox" name="areas" value="Legislação do SUS" checked class="mr-1">Legislação do SUS</label>
+                        <label class="flex items-center"><input type="checkbox" name="areas" value="Sinais Clínicos e Radiológicos" checked class="mr-1">Sinais Clínicos e Radiológicos</label>
+                        <label class="flex items-center"><input type="checkbox" name="areas" value="Anatomia e Fisiologia" class="mr-1">Anatomia e Fisiologia</label>
                     </div>
                 </fieldset>
             </form>

--- a/script.js
+++ b/script.js
@@ -64,6 +64,11 @@ function startQuiz() {
         ? questionBank.filter(q => selectedAreas.includes(q.area))
         : [...questionBank];
 
+    if (bank.length === 0) {
+        alert('Nenhuma questão disponível para as áreas selecionadas.');
+        return;
+    }
+
     shuffle(bank);
     currentQuestions = bank.slice(0, num);
     currentQuestionIndex = 0;


### PR DESCRIPTION
## Summary
- include 'Sinais Clínicos e Radiológicos' and 'Anatomia e Fisiologia' in the area filters
- prevent starting a quiz when no questions match the selected areas

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68705a605c90832b9ca48d052546fba6