### PR TITLE
Add option to flag invalid questions

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,10 @@
                 <div id="feedback-container" class="mt-6 p-4 rounded-lg hidden">
                     <p id="feedback-text" class="font-semibold"></p>
                 </div>
-                <div class="mt-6 text-right">
+                <div class="mt-6 flex justify-between">
+                    <button id="flag-btn" class="bg-red-600 hover:bg-red-700 text-white font-bold py-2 px-4 rounded-lg shadow-md">
+                        Anular Questão
+                    </button>
                     <button id="next-btn" class="bg-[#0094D1] hover:bg-[#007EAF] text-white font-bold py-2 px-6 rounded-lg shadow-md transition-opacity hidden">
                         Próxima Questão &rarr;
                     </button>
@@ -95,6 +98,10 @@
             <button id="print-btn" class="mt-4 bg-[#0094D1] hover:bg-[#007EAF] text-white font-bold py-3 px-8 rounded-lg text-xl shadow-md transition-transform transform hover:scale-105">
                 Imprimir Resultado
             </button>
+            <button id="show-flagged-btn" class="mt-4 bg-yellow-600 hover:bg-yellow-700 text-white font-bold py-3 px-8 rounded-lg text-xl shadow-md transition-transform transform hover:scale-105">
+                Ver Questões Anuladas
+            </button>
+            <div id="flagged-questions" class="mt-4 text-left hidden"></div>
         </div>
 
     </div>

--- a/script.js
+++ b/script.js
@@ -14,6 +14,9 @@ const startBtn = document.getElementById('start-btn');
 const nextBtn = document.getElementById('next-btn');
 const restartBtn = document.getElementById('restart-btn');
 const printBtn = document.getElementById('print-btn');
+const flagBtn = document.getElementById('flag-btn');
+const showFlaggedBtn = document.getElementById('show-flagged-btn');
+const flaggedListEl = document.getElementById('flagged-questions');
 
 const progressBar = document.getElementById('progress-bar');
 const questionCounterEl = document.getElementById('question-counter');
@@ -45,6 +48,7 @@ let timeLeft = 0;
 let currentQuestions = [];
 let currentQuestionIndex = 0;
 let score = 0;
+let flaggedQuestions = [];
 
 function shuffle(array) {
     for (let i = array.length - 1; i > 0; i--) {
@@ -73,6 +77,16 @@ function startQuiz() {
     currentQuestions = bank.slice(0, num);
     currentQuestionIndex = 0;
     score = 0;
+    flaggedQuestions = [];
+    if (flaggedListEl) {
+        flaggedListEl.innerHTML = '';
+        flaggedListEl.classList.add('hidden');
+    }
+    if (flagBtn) {
+        flagBtn.disabled = false;
+        flagBtn.innerText = 'Anular Questão';
+        flagBtn.classList.remove('opacity-50', 'cursor-not-allowed');
+    }
 
     timeLeft = currentQuestions.length * 120;
     updateTimer();
@@ -96,6 +110,11 @@ function startQuiz() {
 function showQuestion() {
     resetState();
     updateProgressBar();
+    if (flagBtn) {
+        flagBtn.disabled = false;
+        flagBtn.innerText = 'Anular Questão';
+        flagBtn.classList.remove('opacity-50', 'cursor-not-allowed');
+    }
     const question = currentQuestions[currentQuestionIndex];
     questionCounterEl.innerText = `Questão ${currentQuestionIndex + 1} de ${currentQuestions.length}`;
     scoreCounterEl.innerText = `Pontos: ${score}`;
@@ -164,6 +183,18 @@ function setStatusClass(element, correct) {
     }
 }
 
+function flagCurrentQuestion() {
+    const question = currentQuestions[currentQuestionIndex];
+    if (!flaggedQuestions.includes(question)) {
+        flaggedQuestions.push(question);
+    }
+    if (flagBtn) {
+        flagBtn.disabled = true;
+        flagBtn.innerText = 'Questão Anulada';
+        flagBtn.classList.add('opacity-50', 'cursor-not-allowed');
+    }
+}
+
 function showResults() {
     clearInterval(timerInterval);
     timerEl.innerText = '';
@@ -184,6 +215,15 @@ function showResults() {
         message = 'Não desanime! Cada simulado é um passo no aprendizado. Revise as explicações e tente novamente.';
     }
     scoreMessageEl.innerText = message;
+
+    if (flaggedListEl) {
+        if (flaggedQuestions.length > 0) {
+            const items = flaggedQuestions.map(q => `<li class="mb-2">${q.question}</li>`).join('');
+            flaggedListEl.innerHTML = `<ul class="list-disc pl-6">${items}</ul>`;
+        } else {
+            flaggedListEl.innerHTML = '<p>Nenhuma questão foi anulada.</p>';
+        }
+    }
 }
 
 startBtn.addEventListener('click', startQuiz);
@@ -194,5 +234,15 @@ nextBtn.addEventListener('click', () => {
 restartBtn.addEventListener('click', startQuiz);
 if (printBtn) {
     printBtn.addEventListener('click', () => window.print());
+}
+if (flagBtn) {
+    flagBtn.addEventListener('click', flagCurrentQuestion);
+}
+if (showFlaggedBtn) {
+    showFlaggedBtn.addEventListener('click', () => {
+        if (flaggedListEl) {
+            flaggedListEl.classList.toggle('hidden');
+        }
+    });
 }
 


### PR DESCRIPTION
## Summary
- add `Anular Questão` button during quizzes
- keep list of flagged questions
- show list after completing the quiz

## Testing
- `node -e "require('./script.js')"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68706fafa178832b8c5be044b02cd709