### PR TITLE
Add export log feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ O projeto utiliza [Tailwind CSS](https://tailwindcss.com) via CDN e possui o est
 
 As questões estão definidas em `script.js` em um array `questionBank`. Cada entrada possui banca, enunciado, opções de resposta, explicação e uma lista de `tags` usadas para futuras filtragens.
 
+Ao final do simulado é possível exportar um log das questões anuladas clicando em **Exportar Log** na tela de resultados.
+
 ## Como adicionar questões
 
 Edite `script.js` e acrescente novos objetos ao `questionBank` seguindo o mesmo formato dos existentes.

--- a/index.html
+++ b/index.html
@@ -101,6 +101,9 @@
             <button id="show-flagged-btn" class="mt-4 bg-yellow-600 hover:bg-yellow-700 text-white font-bold py-3 px-8 rounded-lg text-xl shadow-md transition-transform transform hover:scale-105">
                 Ver Questões Anuladas
             </button>
+            <button id="export-log-btn" class="mt-4 bg-green-600 hover:bg-green-700 text-white font-bold py-3 px-8 rounded-lg text-xl shadow-md transition-transform transform hover:scale-105">
+                Exportar Log
+            </button>
             <div id="flagged-questions" class="mt-4 text-left hidden"></div>
         </div>
 

--- a/script.js
+++ b/script.js
@@ -17,6 +17,7 @@ const printBtn = document.getElementById('print-btn');
 const flagBtn = document.getElementById('flag-btn');
 const showFlaggedBtn = document.getElementById('show-flagged-btn');
 const flaggedListEl = document.getElementById('flagged-questions');
+const exportLogBtn = document.getElementById('export-log-btn');
 
 const progressBar = document.getElementById('progress-bar');
 const questionCounterEl = document.getElementById('question-counter');
@@ -226,6 +227,21 @@ function showResults() {
     }
 }
 
+function exportFlagged() {
+    if (flaggedQuestions.length === 0) {
+        alert('Nenhuma questão anulada para exportar.');
+        return;
+    }
+    const dataStr = JSON.stringify(flaggedQuestions, null, 2);
+    const blob = new Blob([dataStr], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'flagged_questions.json';
+    a.click();
+    URL.revokeObjectURL(url);
+}
+
 startBtn.addEventListener('click', startQuiz);
 nextBtn.addEventListener('click', () => {
     currentQuestionIndex++;
@@ -244,5 +260,8 @@ if (showFlaggedBtn) {
             flaggedListEl.classList.toggle('hidden');
         }
     });
+}
+if (exportLogBtn) {
+    exportLogBtn.addEventListener('click', exportFlagged);
 }
 


### PR DESCRIPTION
## Summary
- enable exporting of flagged questions via new button
- document the log export functionality

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687084dc2218832b9bc262d06895a321