### PR TITLE
Update README for JSON question bank

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,30 @@ Simulador de questões de otorrinolaringologia para concursos. Basta abrir `inde
 
 O projeto utiliza [Tailwind CSS](https://tailwindcss.com) via CDN e possui o estilo em `styles.css` e a lógica em `script.js`.
 
-As questões estão definidas em `script.js` em um array `questionBank`. Cada entrada possui banca, enunciado, opções de resposta, explicação e uma lista de `tags` usadas para futuras filtragens.
+As questões estão definidas em `data/questions.json`. Cada entrada possui `banca`, `question`, `options`, `answer`, `explanation` e `area`.
 
 Ao final do simulado é possível exportar um log das questões anuladas clicando em **Exportar Log** na tela de resultados.
 
 ## Como adicionar questões
 
-Edite `script.js` e acrescente novos objetos ao `questionBank` seguindo o mesmo formato dos existentes.
+Edite `data/questions.json` e acrescente novas questões seguindo o formato abaixo.
 
+```json
+{
+  "banca": "Banca Exemplo",
+  "question": "Enunciado da questão",
+  "options": [
+    "Alternativa A",
+    "Alternativa B",
+    "Alternativa C",
+    "Alternativa D",
+    "Alternativa E"
+  ],
+  "answer": "Alternativa A",
+  "explanation": "Breve justificativa.",
+  "area": "Otologia"
+}
+```
 ## Licença
 
 Distribuído sob a licença MIT. Consulte o arquivo `LICENSE` para mais detalhes.


### PR DESCRIPTION
## Summary
- mention that questions live in `data/questions.json`
- show an example question in JSON format

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6871e7553cc4832bb0b086891e239d7a