### PR TITLE
Add wrong answers review

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,7 +107,11 @@
             <button id="home-btn" class="mt-4 bg-gray-600 hover:bg-gray-700 text-white font-bold py-3 px-8 rounded-lg text-xl shadow-md transition-transform transform hover:scale-105">
                 Voltar ao Início
             </button>
+            <button id="show-wrong-btn" class="mt-4 bg-red-600 hover:bg-red-700 text-white font-bold py-3 px-8 rounded-lg text-xl shadow-md transition-transform transform hover:scale-105">
+                Ver Questões Erradas
+            </button>
             <div id="flagged-questions" class="mt-4 text-left hidden"></div>
+            <div id="wrong-questions" class="mt-4 text-left hidden"></div>
         </div>
 
     </div>

--- a/script.js
+++ b/script.js
@@ -21,6 +21,8 @@ const printBtn = document.getElementById('print-btn');
 const flagBtn = document.getElementById('flag-btn');
 const showFlaggedBtn = document.getElementById('show-flagged-btn');
 const flaggedListEl = document.getElementById('flagged-questions');
+const showWrongBtn = document.getElementById('show-wrong-btn');
+const wrongListEl = document.getElementById('wrong-questions');
 const exportLogBtn = document.getElementById('export-log-btn');
 const homeBtn = document.getElementById('home-btn');
 
@@ -55,6 +57,7 @@ let currentQuestions = [];
 let currentQuestionIndex = 0;
 let score = 0;
 let flaggedQuestions = [];
+let wrongQuestions = [];
 
 function shuffle(array) {
     for (let i = array.length - 1; i > 0; i--) {
@@ -84,9 +87,14 @@ function startQuiz() {
     currentQuestionIndex = 0;
     score = 0;
     flaggedQuestions = [];
+    wrongQuestions = [];
     if (flaggedListEl) {
         flaggedListEl.innerHTML = '';
         flaggedListEl.classList.add('hidden');
+    }
+    if (wrongListEl) {
+        wrongListEl.innerHTML = '';
+        wrongListEl.classList.add('hidden');
     }
     if (flagBtn) {
         flagBtn.disabled = false;
@@ -159,6 +167,14 @@ function selectAnswer(e) {
     const selectedBtn = e.target;
     const correct = selectedBtn.innerText === currentQuestions[currentQuestionIndex].answer;
 
+    if (!correct) {
+        wrongQuestions.push({
+            question: currentQuestions[currentQuestionIndex].question,
+            chosen: selectedBtn.innerText,
+            correct: currentQuestions[currentQuestionIndex].answer
+        });
+    }
+
     if (correct) {
         score++;
         scoreCounterEl.innerText = `Pontos: ${score}`;
@@ -230,6 +246,15 @@ function showResults() {
             flaggedListEl.innerHTML = '<p>Nenhuma questão foi anulada.</p>';
         }
     }
+
+    if (wrongListEl) {
+        if (wrongQuestions.length > 0) {
+            const items = wrongQuestions.map(w => `<li class="mb-2"><strong>${w.question}</strong><br>Sua resposta: ${w.chosen}<br>Correta: ${w.correct}</li>`).join('');
+            wrongListEl.innerHTML = `<ul class="list-disc pl-6">${items}</ul>`;
+        } else {
+            wrongListEl.innerHTML = '<p>Todas as questões foram respondidas corretamente.</p>';
+        }
+    }
 }
 
 function exportFlagged() {
@@ -263,6 +288,13 @@ if (showFlaggedBtn) {
     showFlaggedBtn.addEventListener('click', () => {
         if (flaggedListEl) {
             flaggedListEl.classList.toggle('hidden');
+        }
+    });
+}
+if (showWrongBtn) {
+    showWrongBtn.addEventListener('click', () => {
+        if (wrongListEl) {
+            wrongListEl.classList.toggle('hidden');
         }
     });
 }


### PR DESCRIPTION
## Summary
- add button to display wrong questions and hidden container to hold them
- track wrong answers in script.js and reset when restarting
- list wrong answers on results screen and allow toggling via a button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687299b13f3c832ba3920dd3e2ccb80b