### PR TITLE
Implement quiz progress tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,10 +51,15 @@
                         <label class="flex items-center"><input type="checkbox" name="areas" value="Indicadores de Saúde/Epidemiologia" checked class="mr-1">Indicadores de Saúde/Epidemiologia</label>
                     </div>
                 </fieldset>
+                <label class="flex items-center"><input type="checkbox" id="include-done" class="mr-1">Incluir questões já realizadas</label>
+                <p id="progress-info" class="text-sm text-gray-600"></p>
             </form>
 
             <button id="start-btn" class="bg-[#004AAD] hover:bg-[#003B8A] text-white font-bold py-3 px-8 rounded-lg text-xl shadow-md transition-transform transform hover:scale-105">
                 Iniciar Simulado
+            </button>
+            <button id="clear-progress" class="ml-4 bg-gray-200 hover:bg-gray-300 text-gray-800 font-bold py-3 px-6 rounded-lg text-xl shadow-md transition-transform transform hover:scale-105">
+                Limpar Progresso
             </button>
         </div>
 


### PR DESCRIPTION
## Summary
- keep track of answered questions in `localStorage`
- show progress information on the start screen
- add option to include completed questions
- allow clearing of stored progress

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_6872c77fd788832ba699806c995fbbc5