### PR TITLE
Add JSON validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ Edite `data/questions.json` e acrescente novas questões seguindo o formato abai
   "area": "Otologia"
 }
 ```
+## Validating the question database
+
+Execute o script abaixo para verificar se `data/questions.json` está bem formatado:
+
+```bash
+python3 tools/validate_json.py
+```
+
+Recomenda-se rodá-lo antes de submeter novas questões ao repositório.
+
 ## Licença
 
 Distribuído sob a licença MIT. Consulte o arquivo `LICENSE` para mais detalhes.

--- a/tools/validate_json.py
+++ b/tools/validate_json.py
@@ -1,0 +1,31 @@
+import json
+import sys
+from pathlib import Path
+
+REQUIRED_KEYS = {"banca", "question", "options", "answer", "explanation", "area"}
+
+def main():
+    path = Path(__file__).resolve().parents[1] / "data" / "questions.json"
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception as e:
+        print(f"Failed to load {path}: {e}")
+        sys.exit(1)
+
+    if not isinstance(data, list):
+        print("questions.json should contain a list")
+        sys.exit(1)
+
+    for idx, item in enumerate(data):
+        if not isinstance(item, dict):
+            print(f"Item {idx} is not an object")
+            sys.exit(1)
+        missing = REQUIRED_KEYS - item.keys()
+        if missing:
+            print(f"Item {idx} is missing keys: {', '.join(sorted(missing))}")
+            sys.exit(1)
+    print("Validation successful.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a validation script for questions.json
- document how to run the validation script in the README

## Testing
- `python3 tools/validate_json.py`

------
https://chatgpt.com/codex/tasks/task_e_6872f94f0030832b8fa8b20d8d25d9ca