### PR TITLE
Fix options grid layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
                     <p id="question-text" class="text-xl md:text-2xl font-semibold leading-relaxed"></p>
                     <p id="question-banca" class="text-sm text-gray-500 mt-2 font-mono"></p>
                 </div>
-                <div id="options-container" class="grid grid-cols-1 gap-4">
+                <div id="options-container" class="grid grid-cols-1 md:grid-cols-2 gap-4">
                 </div>
                 <div id="feedback-container" class="mt-6 p-4 rounded-lg hidden">
                     <p id="feedback-text" class="font-semibold"></p>


### PR DESCRIPTION
## Summary
- allow options to align in two columns on medium screens

## Testing
- `python3 tools/validate_json.py` *(fails: Duplicate question at index 277)*

------
https://chatgpt.com/codex/tasks/task_e_6882eec74318832b9f987df50b2eb668